### PR TITLE
Add Zstd/Brotli compression options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ there's a very minimal HTML frontend for posting content.
 
 the primary intended purpose of bytebin is to act as a middle man in the communication of two separate clients, using payload objects (uploaded to a bytebin instance) as a means to transmit data.
 
-it's also quite good for transferring or sharing large log/plain text files because they're particularly compressible with gzip.
+it's also quite good for transferring or sharing large log/plain text files because they're particularly compressible with gzip/zstd.
 
 ## api usage
 
@@ -25,7 +25,7 @@ The API fully supports CORS. wooo :tada:
 * send a POST request to `/post`.
 * the request body should contain the content to be uploaded.
 * it is recommended to provide `Content-Type` and `User-Agent` headers, but this is not required.
-* ideally, content should be compressed with GZIP before being uploaded. Include the `Content-Encoding: gzip` header if this is the case.
+* ideally, content should be compressed with GZIP or Zstd before being uploaded. Include the `Content-Encoding: gzip` or `Content-Encoding: zstd` header if this is the case.
 * the key is specified in the returned `Location` header.
 * the response body is a JSON object with only one property, `{"key": "{key}"}`.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ there's a very minimal HTML frontend for posting content.
 
 the primary intended purpose of bytebin is to act as a middle man in the communication of two separate clients, using payload objects (uploaded to a bytebin instance) as a means to transmit data.
 
-it's also quite good for transferring or sharing large log/plain text files because they're particularly compressible with gzip/zstd.
+it's also quite good for transferring or sharing large log/plain text files because they're particularly compressible with gzip/brotli/zstd.
 
 ## api usage
 
@@ -25,7 +25,7 @@ The API fully supports CORS. wooo :tada:
 * send a POST request to `/post`.
 * the request body should contain the content to be uploaded.
 * it is recommended to provide `Content-Type` and `User-Agent` headers, but this is not required.
-* ideally, content should be compressed with GZIP or Zstd before being uploaded. Include the `Content-Encoding: gzip` or `Content-Encoding: zstd` header if this is the case.
+* ideally, content should be compressed with GZIP, Brotli, or Zstd before being uploaded. Include the `Content-Encoding: gzip`, `Content-Encoding: br`, or `Content-Encoding: zstd` header if this is the case.
 * the key is specified in the returned `Location` header.
 * the response body is a JSON object with only one property, `{"key": "{key}"}`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,11 @@
             <artifactId>zstd-jni</artifactId>
             <version>1.4.8-3</version>
         </dependency>
+        <dependency>
+            <groupId>com.nixxcode.jvmbrotli</groupId>
+            <artifactId>jvmbrotli</artifactId>
+            <version>0.2.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
             <artifactId>caffeine</artifactId>
             <version>2.8.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+            <version>1.4.8-3</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/me/lucko/bytebin/Bytebin.java
+++ b/src/main/java/me/lucko/bytebin/Bytebin.java
@@ -28,6 +28,7 @@ package me.lucko.bytebin;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharStreams;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.nixxcode.jvmbrotli.common.BrotliLoader;
 import me.lucko.bytebin.content.Content;
 import me.lucko.bytebin.content.ContentCache;
 import me.lucko.bytebin.content.ContentStorageHandler;
@@ -62,6 +63,12 @@ public final class Bytebin implements AutoCloseable {
         // setup logging
         System.setOut(IoBuilder.forLogger(LOGGER).setLevel(Level.INFO).buildPrintStream());
         System.setErr(IoBuilder.forLogger(LOGGER).setLevel(Level.ERROR).buildPrintStream());
+
+        // setup Brotli
+        if (!BrotliLoader.isBrotliAvailable()) {
+            LOGGER.error("Brotli is unavailable.");
+            return;
+        }
 
         // setup a new bytebin instance
         Configuration config = Configuration.load(Paths.get("config.json"));

--- a/src/main/java/me/lucko/bytebin/content/Content.java
+++ b/src/main/java/me/lucko/bytebin/content/Content.java
@@ -25,6 +25,8 @@
 
 package me.lucko.bytebin.content;
 
+import me.lucko.bytebin.util.Compression;
+
 /**
  * Encapsulates content within the service
  */
@@ -34,7 +36,7 @@ public final class Content {
     public static final byte[] EMPTY_BYTES = new byte[0];
 
     /** Empty content instance */
-    public static final Content EMPTY_CONTENT = new Content(null, "text/plain", Long.MAX_VALUE, Long.MIN_VALUE, false, null, EMPTY_BYTES);
+    public static final Content EMPTY_CONTENT = new Content(null, "text/plain", Long.MAX_VALUE, Long.MIN_VALUE, false, null, EMPTY_BYTES, null);
 
     /** Number of bytes in a megabyte */
     public static final long MEGABYTE_LENGTH = 1024L * 1024L;
@@ -46,8 +48,9 @@ public final class Content {
     private final boolean modifiable;
     private final String authKey;
     private byte[] content;
+    private Compression.CompressionType compressionType;
 
-    public Content(String key, String contentType, long expiry, long lastModified, boolean modifiable, String authKey, byte[] content) {
+    public Content(String key, String contentType, long expiry, long lastModified, boolean modifiable, String authKey, byte[] content, Compression.CompressionType compressionType) {
         this.key = key;
         this.contentType = contentType;
         this.expiry = expiry;
@@ -55,6 +58,7 @@ public final class Content {
         this.modifiable = modifiable;
         this.authKey = authKey;
         this.content = content;
+        this.compressionType = compressionType;
     }
 
     public String getKey() {
@@ -99,6 +103,14 @@ public final class Content {
 
     public void setContent(byte[] content) {
         this.content = content;
+    }
+
+    public Compression.CompressionType getCompressionType() {
+        return compressionType;
+    }
+
+    public void setCompressionType(Compression.CompressionType compressionType) {
+        this.compressionType = compressionType;
     }
 
     public boolean shouldExpire() {

--- a/src/main/java/me/lucko/bytebin/http/PutHandler.java
+++ b/src/main/java/me/lucko/bytebin/http/PutHandler.java
@@ -106,9 +106,9 @@ public final class PutHandler implements ReqHandler {
             String newContentType = req.header("Content-Type", oldContent.getContentType());
 
             // compress if necessary
-            boolean compressed = req.header("Content-Encoding", "").equals("gzip");
-            if (!compressed) {
-                newContent.set(Compression.compress(newContent.get()));
+            Compression.CompressionType compressionType = Compression.CompressionType.getCompression(req.header("Content-Encoding", ""));
+            if (compressionType != null) {
+                newContent.set(Compression.compress(newContent.get(), compressionType));
             }
 
             // check max content length

--- a/src/main/java/me/lucko/bytebin/util/Compression.java
+++ b/src/main/java/me/lucko/bytebin/util/Compression.java
@@ -26,6 +26,7 @@
 package me.lucko.bytebin.util;
 
 import com.google.common.base.Splitter;
+import me.lucko.bytebin.util.compression.BrotliCompressionStream;
 import me.lucko.bytebin.util.compression.GZIPCompressionStream;
 import me.lucko.bytebin.util.compression.ZSTDCompressionStream;
 import org.rapidoid.http.Req;
@@ -51,6 +52,7 @@ public final class Compression {
     }
 
     private static final GZIPCompressionStream GZIP_STREAM = new GZIPCompressionStream();
+    private static final BrotliCompressionStream BROTLI_STREAM = new BrotliCompressionStream();
     private static final ZSTDCompressionStream ZSTD_STREAM = new ZSTDCompressionStream();
 
     public static byte[] compress(byte[] buf, CompressionType type) {
@@ -62,6 +64,8 @@ public final class Compression {
             switch (type) {
                 case GZIP:
                     return GZIP_STREAM.compress(buf);
+                case BROTLI:
+                    return BROTLI_STREAM.compress(buf);
                 case ZSTD:
                     return ZSTD_STREAM.compress(buf);
                 default:
@@ -80,6 +84,8 @@ public final class Compression {
         switch (type) {
             case GZIP:
                 return GZIP_STREAM.decompress(buf);
+            case BROTLI:
+                return BROTLI_STREAM.decompress(buf);
             case ZSTD:
                 return ZSTD_STREAM.decompress(buf);
             default:
@@ -89,6 +95,7 @@ public final class Compression {
 
     public enum CompressionType {
         GZIP("gzip"),
+        BROTLI("br"),
         ZSTD("zstd");
 
         private final String name;

--- a/src/main/java/me/lucko/bytebin/util/Compression.java
+++ b/src/main/java/me/lucko/bytebin/util/Compression.java
@@ -26,6 +26,7 @@
 package me.lucko.bytebin.util;
 
 import com.google.common.base.Splitter;
+import java.util.regex.Pattern;
 import me.lucko.bytebin.util.compression.BrotliCompressionStream;
 import me.lucko.bytebin.util.compression.GZIPCompressionStream;
 import me.lucko.bytebin.util.compression.ZSTDCompressionStream;
@@ -36,13 +37,14 @@ import java.io.IOException;
 public final class Compression {
     private Compression() {}
 
-    private static final Splitter COMMA_SPLITTER = Splitter.on(", ");
+    private static final Splitter COMMA_SPLITTER = Splitter.on(Pattern.compile(",\\s*"));
+    private static final Pattern RE_SEMICOLON = Pattern.compile(";\\s*");
 
     public static CompressionType compressionType(Req req) {
         String header = req.header("Accept-Encoding", null);
         if (header != null) {
             for (String typeStr : COMMA_SPLITTER.split(header)) {
-                CompressionType type = CompressionType.getCompression(typeStr);
+                CompressionType type = CompressionType.getCompression(RE_SEMICOLON.split(typeStr)[0]);
                 if (type != null) {
                     return type;
                 }

--- a/src/main/java/me/lucko/bytebin/util/compression/AbstractCompressionStream.java
+++ b/src/main/java/me/lucko/bytebin/util/compression/AbstractCompressionStream.java
@@ -1,0 +1,9 @@
+package me.lucko.bytebin.util.compression;
+
+import java.io.IOException;
+
+public abstract class AbstractCompressionStream {
+    public abstract byte[] compress(byte[] buf) throws IOException;
+    public abstract byte[] decompress(byte[] buf) throws IOException;
+
+}

--- a/src/main/java/me/lucko/bytebin/util/compression/BrotliCompressionStream.java
+++ b/src/main/java/me/lucko/bytebin/util/compression/BrotliCompressionStream.java
@@ -1,0 +1,29 @@
+package me.lucko.bytebin.util.compression;
+
+import com.google.common.io.ByteStreams;
+import com.nixxcode.jvmbrotli.dec.BrotliInputStream;
+import com.nixxcode.jvmbrotli.enc.BrotliOutputStream;
+import com.nixxcode.jvmbrotli.enc.Encoder;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class BrotliCompressionStream extends AbstractCompressionStream {
+    private static final Encoder.Parameters PARAMS = new Encoder.Parameters().setQuality(4);
+
+    public byte[] compress(byte[] buf) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream(buf.length);
+        try (BrotliOutputStream brotliOut = new BrotliOutputStream(out, PARAMS)) {
+            brotliOut.write(buf);
+        }
+        return out.toByteArray();
+    }
+
+    public byte[] decompress(byte[] buf) throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream(buf);
+        try (BrotliInputStream brotliIn = new BrotliInputStream(in)) {
+            return ByteStreams.toByteArray(brotliIn);
+        }
+    }
+
+}

--- a/src/main/java/me/lucko/bytebin/util/compression/GZIPCompressionStream.java
+++ b/src/main/java/me/lucko/bytebin/util/compression/GZIPCompressionStream.java
@@ -1,0 +1,29 @@
+package me.lucko.bytebin.util.compression;
+
+import com.google.common.io.ByteStreams;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class GZIPCompressionStream extends AbstractCompressionStream {
+    @Override
+    public byte[] compress(byte[] buf) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream(buf.length);
+        try (GZIPOutputStream gzipOut = new GZIPOutputStream(out)) {
+            gzipOut.write(buf);
+        }
+        return out.toByteArray();
+    }
+
+    @Override
+    public byte[] decompress(byte[] buf) throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream(buf);
+        try (GZIPInputStream gzipIn = new GZIPInputStream(in)) {
+            return ByteStreams.toByteArray(gzipIn);
+        }
+    }
+
+}

--- a/src/main/java/me/lucko/bytebin/util/compression/ZSTDCompressionStream.java
+++ b/src/main/java/me/lucko/bytebin/util/compression/ZSTDCompressionStream.java
@@ -1,0 +1,29 @@
+package me.lucko.bytebin.util.compression;
+
+import com.github.luben.zstd.ZstdInputStream;
+import com.github.luben.zstd.ZstdOutputStream;
+import com.google.common.io.ByteStreams;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class ZSTDCompressionStream extends AbstractCompressionStream {
+    @Override
+    public byte[] compress(byte[] buf) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream(buf.length);
+        try (ZstdOutputStream zstdOut = new ZstdOutputStream(out, 9)) {
+            zstdOut.write(buf);
+        }
+        return out.toByteArray();
+    }
+
+    @Override
+    public byte[] decompress(byte[] buf) throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream(buf);
+        try (ZstdInputStream zstdIn = new ZstdInputStream(in)) {
+            return ByteStreams.toByteArray(zstdIn);
+        }
+    }
+
+}


### PR DESCRIPTION
IANA headers and media type defined in RFC 8478 section 6: https://tools.ietf.org/search/rfc8478#section-6
This is a dictionary-less approach as outlined in RFC 8478 section 7: https://tools.ietf.org/search/rfc8478#section-7

Media type has not been addressed, but I'm following the standard laid out in the application for GZIP.