### PR TITLE
Adjust Cache-Control max-age header based on content expiry

### DIFF
--- a/src/main/java/me/lucko/bytebin/http/GetHandler.java
+++ b/src/main/java/me/lucko/bytebin/http/GetHandler.java
@@ -105,10 +105,11 @@ public final class GetHandler implements ReqHandler {
 
             Resp resp = cors(req.response()).code(200).header("Last-Modified", lastModifiedTime);
 
-            if (content.isModifiable()) {
+            long expires = content.getExpiry() - System.currentTimeMillis();
+            if (content.isModifiable() || expires <= 0L) {
                 resp.header("Cache-Control", "no-cache");
             } else {
-                resp.header("Cache-Control", "public, max-age=" + (content.getExpiry() / 1000L));
+                resp.header("Cache-Control", "public, max-age=" + (expires / 1000L));
             }
 
             // will the client accept the content in a compressed form?

--- a/src/main/java/me/lucko/bytebin/http/GetHandler.java
+++ b/src/main/java/me/lucko/bytebin/http/GetHandler.java
@@ -108,7 +108,7 @@ public final class GetHandler implements ReqHandler {
             if (content.isModifiable()) {
                 resp.header("Cache-Control", "no-cache");
             } else {
-                resp.header("Cache-Control", "public, max-age=86400");
+                resp.header("Cache-Control", "public, max-age=" + (content.getExpiry() / 1000L));
             }
 
             // will the client accept the content in a compressed form?


### PR DESCRIPTION
This allows Cloudflare to better cache the response from the server, all the way up until it actually expires.