### PR TITLE
Add support for multiple content encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The API fully supports CORS. wooo :tada:
 * send a POST request to `/post`.
 * the request body should contain the content to be uploaded.
 * it is recommended to provide `Content-Type` and `User-Agent` headers, but this is not required.
-* ideally, content should be compressed with GZIP before being uploaded. Include the `Content-Encoding: gzip` header if this is the case.
+* ideally, content should be compressed with GZIP or another mechanism before being uploaded. Include the `Content-Encoding: <type>` header if this is the case.
 * the key is specified in the returned `Location` header.
 * the response body is a JSON object with only one property, `{"key": "{key}"}`.
 

--- a/src/main/java/me/lucko/bytebin/content/Content.java
+++ b/src/main/java/me/lucko/bytebin/content/Content.java
@@ -25,6 +25,8 @@
 
 package me.lucko.bytebin.content;
 
+import me.lucko.bytebin.util.ContentEncoding;
+
 /**
  * Encapsulates content within the service
  */
@@ -34,7 +36,7 @@ public final class Content {
     public static final byte[] EMPTY_BYTES = new byte[0];
 
     /** Empty content instance */
-    public static final Content EMPTY_CONTENT = new Content(null, "text/plain", Long.MAX_VALUE, Long.MIN_VALUE, false, null, EMPTY_BYTES);
+    public static final Content EMPTY_CONTENT = new Content(null, "text/plain", Long.MAX_VALUE, Long.MIN_VALUE, false, null, ContentEncoding.IDENTITY.getEncoding(), EMPTY_BYTES);
 
     /** Number of bytes in a megabyte */
     public static final long MEGABYTE_LENGTH = 1024L * 1024L;
@@ -45,15 +47,17 @@ public final class Content {
     private long lastModified;
     private final boolean modifiable;
     private final String authKey;
+    private String encoding;
     private byte[] content;
 
-    public Content(String key, String contentType, long expiry, long lastModified, boolean modifiable, String authKey, byte[] content) {
+    public Content(String key, String contentType, long expiry, long lastModified, boolean modifiable, String authKey, String encoding, byte[] content) {
         this.key = key;
         this.contentType = contentType;
         this.expiry = expiry;
         this.lastModified = lastModified;
         this.modifiable = modifiable;
         this.authKey = authKey;
+        this.encoding = encoding;
         this.content = content;
     }
 
@@ -91,6 +95,14 @@ public final class Content {
 
     public String getAuthKey() {
         return this.authKey;
+    }
+
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
     }
 
     public byte[] getContent() {

--- a/src/main/java/me/lucko/bytebin/http/GetHandler.java
+++ b/src/main/java/me/lucko/bytebin/http/GetHandler.java
@@ -25,8 +25,10 @@
 
 package me.lucko.bytebin.http;
 
+import java.util.List;
 import me.lucko.bytebin.content.ContentCache;
 import me.lucko.bytebin.util.Compression;
+import me.lucko.bytebin.util.ContentEncoding;
 import me.lucko.bytebin.util.RateLimiter;
 import me.lucko.bytebin.util.TokenGenerator;
 import org.apache.logging.log4j.LogManager;
@@ -72,7 +74,7 @@ public final class GetHandler implements ReqHandler {
         if (this.rateLimiter.check(ipAddress)) return cors(req.response()).code(429).plain("Rate limit exceeded");
 
         // request the file from the cache async
-        boolean supportsCompression = Compression.acceptsCompressed(req);
+        List<String> supportedEncodings = Compression.getSupportedEncoding(req);
 
         /*this.server.getLoggingExecutor().submit(() -> {
             String hostname = null;
@@ -92,7 +94,7 @@ public final class GetHandler implements ReqHandler {
                     //"    origin = " + ipAddress + (hostname != null ? " (" + hostname + ")" : "") + "\n" +
                     "    ip = " + ipAddress + "\n" +
                     (origin == null ? "" : "    origin = " + origin + "\n"));
-                    //"    supports compression = " + supportsCompression + "\n");
+                    //"    supports compression = " + (supportedEncodings.size() == 2 && ("gzip".equals(supportedEncodings.get(0)) || "x-gzip".equals(supportedEncodings.get(0)))) + "\n");
         //});
 
         this.contentCache.get(path).whenCompleteAsync((content, throwable) -> {
@@ -112,8 +114,24 @@ public final class GetHandler implements ReqHandler {
                 resp.header("Cache-Control", "public, max-age=" + (expires / 1000L));
             }
 
-            // will the client accept the content in a compressed form?
-            if (supportsCompression) {
+            List<String> encodingStrings = Compression.getProvidedEncoding(content.getEncoding());
+            List<ContentEncoding> encodings = ContentEncoding.getEncoding(encodingStrings);
+
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding
+            if (encodings.contains(ContentEncoding.OTHER)) {
+                // content-encoding is unknown, so must match accept-encoding
+                if (supportedEncodings.contains("*") || supportedEncodings.containsAll(Compression.getProvidedEncoding(content.getEncoding()))) {
+                    resp.header("Content-Encoding", content.getEncoding())
+                            .body(content.getContent())
+                            .contentType(MediaType.of(content.getContentType()))
+                            .done();
+                } else {
+                    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406
+                    cors(req.response()).code(406).plain("Accept-Encoding \"" + req.header("Accept-Encoding", "") + "\" does not contain Content-Encoding \"" + content.getEncoding() + "\"").done();
+                }
+                return;
+            } else if ((encodings.size() == 2 && encodings.get(0) == ContentEncoding.GZIP) && (supportedEncodings.contains("*") || (supportedEncodings.size() == 2 && ("gzip".equals(supportedEncodings.get(0)) || "x-gzip".equals(supportedEncodings.get(0)))))) {
+                // the client will accept gzip
                 resp.header("Content-Encoding", "gzip")
                         .body(content.getContent())
                         .contentType(MediaType.of(content.getContentType()))

--- a/src/main/java/me/lucko/bytebin/http/GetHandler.java
+++ b/src/main/java/me/lucko/bytebin/http/GetHandler.java
@@ -120,7 +120,7 @@ public final class GetHandler implements ReqHandler {
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding
             if (encodings.contains(ContentEncoding.OTHER)) {
                 // content-encoding is unknown, so must match accept-encoding
-                if (supportedEncodings.contains("*") || supportedEncodings.containsAll(Compression.getProvidedEncoding(content.getEncoding()))) {
+                if (supportedEncodings.contains("*") || supportedEncodings.containsAll(encodingStrings)) {
                     resp.header("Content-Encoding", content.getEncoding())
                             .body(content.getContent())
                             .contentType(MediaType.of(content.getContentType()))

--- a/src/main/java/me/lucko/bytebin/http/GetHandler.java
+++ b/src/main/java/me/lucko/bytebin/http/GetHandler.java
@@ -94,7 +94,7 @@ public final class GetHandler implements ReqHandler {
                     //"    origin = " + ipAddress + (hostname != null ? " (" + hostname + ")" : "") + "\n" +
                     "    ip = " + ipAddress + "\n" +
                     (origin == null ? "" : "    origin = " + origin + "\n"));
-                    //"    supports compression = " + (supportedEncodings.size() == 2 && ("gzip".equals(supportedEncodings.get(0)) || "x-gzip".equals(supportedEncodings.get(0)))) + "\n");
+                    //"    supports compression = " + (supportedEncodings.size() == 2 && ContentEncoding.GZIP.getEncoding().equals(supportedEncodings.get(0))) + "\n");
         //});
 
         this.contentCache.get(path).whenCompleteAsync((content, throwable) -> {
@@ -130,9 +130,9 @@ public final class GetHandler implements ReqHandler {
                     cors(req.response()).code(406).plain("Accept-Encoding \"" + req.header("Accept-Encoding", "") + "\" does not contain Content-Encoding \"" + content.getEncoding() + "\"").done();
                 }
                 return;
-            } else if ((encodings.size() == 2 && encodings.get(0) == ContentEncoding.GZIP) && (supportedEncodings.contains("*") || (supportedEncodings.size() == 2 && ("gzip".equals(supportedEncodings.get(0)) || "x-gzip".equals(supportedEncodings.get(0)))))) {
+            } else if ((encodings.size() == 2 && encodings.get(0) == ContentEncoding.GZIP) && (supportedEncodings.contains("*") || (supportedEncodings.size() == 2 && ContentEncoding.GZIP.getEncoding().equals(supportedEncodings.get(0))))) {
                 // the client will accept gzip
-                resp.header("Content-Encoding", "gzip")
+                resp.header("Content-Encoding", ContentEncoding.GZIP.getEncoding())
                         .body(content.getContent())
                         .contentType(MediaType.of(content.getContentType()))
                         .done();

--- a/src/main/java/me/lucko/bytebin/http/PutHandler.java
+++ b/src/main/java/me/lucko/bytebin/http/PutHandler.java
@@ -107,8 +107,11 @@ public final class PutHandler implements ReqHandler {
             // determine the new content type
             String newContentType = req.header("Content-Type", oldContent.getContentType());
 
+            // determine new encoding
+            String newEncoding = req.header("Content-Encoding", oldContent.getEncoding());
+
             // compress if necessary
-            List<ContentEncoding> encodings = ContentEncoding.getEncoding(Compression.getProvidedEncoding(req.header("Content-Encoding", "")));
+            List<ContentEncoding> encodings = ContentEncoding.getEncoding(Compression.getProvidedEncoding(newEncoding));
             boolean compressed = encodings.size() == 2 && encodings.get(0) == ContentEncoding.GZIP;
             if (!compressed) {
                 newContent.set(Compression.compress(newContent.get()));
@@ -138,6 +141,7 @@ public final class PutHandler implements ReqHandler {
                 LOGGER.info("[PUT]\n" +
                         "    key = " + path + "\n" +
                         "    new type = " + new String(newContentType.getBytes()) + "\n" +
+                        "    new encoding = " + new String(newEncoding.getBytes()) + "\n" +
                         "    user agent = " + req.header("User-Agent", "null") + "\n" +
                         //"    origin = " + ipAddress + (hostname != null ? " (" + hostname + ")" : "") + "\n" +
                         "    ip = " + ipAddress + "\n" +
@@ -148,6 +152,7 @@ public final class PutHandler implements ReqHandler {
 
             // update the content instance with the new data
             oldContent.setContentType(newContentType);
+            oldContent.setEncoding(newEncoding);
             oldContent.setExpiry(newExpiry);
             oldContent.setLastModified(System.currentTimeMillis());
             oldContent.setContent(newContent.get());

--- a/src/main/java/me/lucko/bytebin/http/PutHandler.java
+++ b/src/main/java/me/lucko/bytebin/http/PutHandler.java
@@ -25,10 +25,12 @@
 
 package me.lucko.bytebin.http;
 
+import java.util.List;
 import me.lucko.bytebin.content.Content;
 import me.lucko.bytebin.content.ContentCache;
 import me.lucko.bytebin.content.ContentStorageHandler;
 import me.lucko.bytebin.util.Compression;
+import me.lucko.bytebin.util.ContentEncoding;
 import me.lucko.bytebin.util.RateLimiter;
 import me.lucko.bytebin.util.TokenGenerator;
 import org.apache.logging.log4j.LogManager;
@@ -106,7 +108,8 @@ public final class PutHandler implements ReqHandler {
             String newContentType = req.header("Content-Type", oldContent.getContentType());
 
             // compress if necessary
-            boolean compressed = req.header("Content-Encoding", "").equals("gzip");
+            List<ContentEncoding> encodings = ContentEncoding.getEncoding(Compression.getProvidedEncoding(req.header("Content-Encoding", "")));
+            boolean compressed = encodings.size() == 2 && encodings.get(0) == ContentEncoding.GZIP;
             if (!compressed) {
                 newContent.set(Compression.compress(newContent.get()));
             }

--- a/src/main/java/me/lucko/bytebin/util/Compression.java
+++ b/src/main/java/me/lucko/bytebin/util/Compression.java
@@ -53,8 +53,8 @@ public final class Compression {
                 retVal.add("x-gzip".equals(typeStr) ? ContentEncoding.GZIP.getEncoding() : typeStr);
             }
         }
-        if (!retVal.contains("identity") && !retVal.contains("*")) {
-            retVal.add("identity");
+        if (!retVal.contains("*") && !retVal.contains(ContentEncoding.IDENTITY.getEncoding())) {
+            retVal.add(ContentEncoding.IDENTITY.getEncoding());
         }
         return retVal;
     }
@@ -66,8 +66,8 @@ public final class Compression {
                 retVal.add("x-gzip".equals(typeStr) ? ContentEncoding.GZIP.getEncoding() : typeStr);
             }
         }
-        if (!retVal.contains("identity")) {
-            retVal.add("identity");
+        if (!retVal.contains(ContentEncoding.IDENTITY.getEncoding())) {
+            retVal.add(ContentEncoding.IDENTITY.getEncoding());
         }
         return retVal;
     }

--- a/src/main/java/me/lucko/bytebin/util/Compression.java
+++ b/src/main/java/me/lucko/bytebin/util/Compression.java
@@ -26,8 +26,10 @@
 package me.lucko.bytebin.util;
 
 import com.google.common.base.Splitter;
-import com.google.common.collect.Iterables;
 import com.google.common.io.ByteStreams;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
 import org.rapidoid.http.Req;
 
 import java.io.ByteArrayInputStream;
@@ -39,11 +41,34 @@ import java.util.zip.GZIPOutputStream;
 public final class Compression {
     private Compression() {}
 
-    private static final Splitter COMMA_SPLITTER = Splitter.on(", ");
+    private static final Splitter COMMA_SPLITTER = Splitter.on(Pattern.compile(",\\s*"));
+    private static final Pattern RE_SEMICOLON = Pattern.compile(";\\s*");
 
-    public static boolean acceptsCompressed(Req req) {
+    public static List<String> getSupportedEncoding(Req req) {
+        List<String> retVal = new ArrayList<>(2);
         String header = req.header("Accept-Encoding", null);
-        return header != null && Iterables.contains(COMMA_SPLITTER.split(header), "gzip");
+        if (header != null) {
+            for (String typeStr : COMMA_SPLITTER.split(header)) {
+                retVal.add(RE_SEMICOLON.split(typeStr)[0]);
+            }
+        }
+        if (!retVal.contains("identity") && !retVal.contains("*")) {
+            retVal.add("identity");
+        }
+        return retVal;
+    }
+
+    public static List<String> getProvidedEncoding(String header) {
+        List<String> retVal = new ArrayList<>(2);
+        if (header != null && !header.isEmpty()) {
+            for (String typeStr : COMMA_SPLITTER.split(header)) {
+                retVal.add(typeStr);
+            }
+        }
+        if (!retVal.contains("identity")) {
+            retVal.add("identity");
+        }
+        return retVal;
     }
 
     public static byte[] compress(byte[] buf) {

--- a/src/main/java/me/lucko/bytebin/util/Compression.java
+++ b/src/main/java/me/lucko/bytebin/util/Compression.java
@@ -49,7 +49,8 @@ public final class Compression {
         String header = req.header("Accept-Encoding", null);
         if (header != null) {
             for (String typeStr : COMMA_SPLITTER.split(header)) {
-                retVal.add(RE_SEMICOLON.split(typeStr)[0]);
+                typeStr = RE_SEMICOLON.split(typeStr)[0];
+                retVal.add("x-gzip".equals(typeStr) ? ContentEncoding.GZIP.getEncoding() : typeStr);
             }
         }
         if (!retVal.contains("identity") && !retVal.contains("*")) {
@@ -62,7 +63,7 @@ public final class Compression {
         List<String> retVal = new ArrayList<>(2);
         if (header != null && !header.isEmpty()) {
             for (String typeStr : COMMA_SPLITTER.split(header)) {
-                retVal.add(typeStr);
+                retVal.add("x-gzip".equals(typeStr) ? ContentEncoding.GZIP.getEncoding() : typeStr);
             }
         }
         if (!retVal.contains("identity")) {

--- a/src/main/java/me/lucko/bytebin/util/ContentEncoding.java
+++ b/src/main/java/me/lucko/bytebin/util/ContentEncoding.java
@@ -1,0 +1,56 @@
+package me.lucko.bytebin.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public enum ContentEncoding {
+
+    IDENTITY("identity"),
+    GZIP("gzip"),
+    OTHER("");
+
+    private final String encoding;
+    ContentEncoding(String encoding) {
+        this.encoding = encoding;
+    }
+
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public static ContentEncoding getEncoding(String encoding) {
+        if (encoding == null || encoding.isEmpty()) {
+            return IDENTITY;
+        }
+        for (ContentEncoding type : values()) {
+            if (encoding.equals(type.encoding) || (encoding.equals("x-gzip") && type == GZIP)) {
+                return type;
+            }
+        }
+        return OTHER;
+    }
+
+    public static List<ContentEncoding> getEncoding(List<String> encoding) {
+        List<ContentEncoding> retVal = new ArrayList<>(2);
+        if (encoding != null && !encoding.isEmpty()) {
+            for (String typeStr : encoding) {
+                boolean added = false;
+                for (ContentEncoding type : values()) {
+                    if (typeStr.equals(type.encoding) || (typeStr.equals("x-gzip") && type == GZIP)) {
+                        retVal.add(type);
+                        added = true;
+                        break;
+                    }
+                }
+                if (!added) {
+                    retVal.add(OTHER);
+                }
+            }
+        }
+        if (!retVal.contains(IDENTITY)) {
+            retVal.add(IDENTITY);
+        }
+        return retVal;
+    }
+
+}

--- a/src/main/java/me/lucko/bytebin/util/ContentEncoding.java
+++ b/src/main/java/me/lucko/bytebin/util/ContentEncoding.java
@@ -23,7 +23,7 @@ public enum ContentEncoding {
             return IDENTITY;
         }
         for (ContentEncoding type : values()) {
-            if (encoding.equals(type.encoding) || (encoding.equals("x-gzip") && type == GZIP)) {
+            if (encoding.equals(type.encoding)) {
                 return type;
             }
         }
@@ -36,7 +36,7 @@ public enum ContentEncoding {
             for (String typeStr : encoding) {
                 boolean added = false;
                 for (ContentEncoding type : values()) {
-                    if (typeStr.equals(type.encoding) || (typeStr.equals("x-gzip") && type == GZIP)) {
+                    if (typeStr.equals(type.encoding)) {
                         retVal.add(type);
                         added = true;
                         break;


### PR DESCRIPTION
After discussion, this closes #5 

Handling `Content-Encoding` and `Accept-Encoding` properly is difficult, because both allow for comma-separated values.
This PR *should* properly handle transparent GZIP disk compression as well as other forms of content encoding that don't require compression.
This also should handle `;q=` in the `Accept-Encoding` header, but only respects the order in which the encoding is given rather than the q-value for the encoding. A future PR may solve this behavior.