### PR TITLE
Prevent internal error on null request

### DIFF
--- a/src/main/java/me/lucko/bytebin/http/PostHandler.java
+++ b/src/main/java/me/lucko/bytebin/http/PostHandler.java
@@ -83,7 +83,7 @@ public final class PostHandler implements ReqHandler {
         String ipAddress = BytebinServer.getIpAddress(req);
 
         // ensure something was actually posted
-        if (content.length == 0) return cors(req.response()).code(400).plain("Missing content");
+        if (content == null || content.length == 0) return cors(req.response()).code(400).plain("Missing content");
         // check rate limits
         if (this.rateLimiter.check(ipAddress)) return cors(req.response()).code(429).plain("Rate limit exceeded");
 


### PR DESCRIPTION
When you make a post request to `/post` and the body is empty it cause a `NullPointerException`.