### PR TITLE
Remove redundant check in ID validation logic

### DIFF
--- a/src/main/java/me/lucko/bytebin/http/GetHandler.java
+++ b/src/main/java/me/lucko/bytebin/http/GetHandler.java
@@ -71,7 +71,7 @@ public final class GetHandler implements Route.Handler {
     public CompletableFuture<byte[]> apply(@Nonnull Context ctx) {
         // get the requested path
         String path = ctx.path("id").value();
-        if (path.trim().isEmpty() || path.contains(".") || TokenGenerator.INVALID_TOKEN_PATTERN.matcher(path).find()) {
+        if (path.trim().isEmpty() || TokenGenerator.INVALID_TOKEN_PATTERN.matcher(path).find()) {
             throw new StatusCodeException(StatusCode.NOT_FOUND, "Invalid path");
         }
 


### PR DESCRIPTION
Since `INVALID_TOKEN_PATTERN` catches the dot character, the `path.contains(".")` check appears to be redundant when validating paste ids.
![regex](https://github.com/user-attachments/assets/a1836eb1-c463-4fb0-a9e0-cfe761714267)
Feel free to correct me if I'm wrong or missing something.